### PR TITLE
Add TOA DAC threshold setting

### DIFF
--- a/daq-zmq-server.py
+++ b/daq-zmq-server.py
@@ -48,6 +48,7 @@ if __name__ == "__main__":
                 the_bit_string.set_lg_shaping_time(daq_options['shapingTime'])
                 the_bit_string.set_hg_shaping_time(daq_options['shapingTime'])
                 the_bit_string.set_tot_dac_threshold(daq_options['totDACThreshold'])
+                the_bit_string.set_toa_dac_threshold(daq_options['toaDACThreshold'])
                 the_bit_string.Print()
                 the_bits_c_uchar_p=the_bit_string.get_48_unsigned_char_p()
                 outputBitString=theDaq.configure(the_bits_c_uchar_p)

--- a/default-config.yaml
+++ b/default-config.yaml
@@ -10,8 +10,9 @@ daq_options:
  channelIdsDisableTOA: [22]
  injectionDAC: 1000
  pulseDelay: 72
- preampFeedbackCapacitance: 8 
+ preampFeedbackCapacitance: 8
  totDACThreshold: 200
+ toaDACThreshold: 270
  shapingTime: 40
 glb_options:
  moduleNumber: a_very_descriptive_string

--- a/skiroc2cms_bit_string.py
+++ b/skiroc2cms_bit_string.py
@@ -102,6 +102,12 @@ class bit_string:
         for i in range(0,10):
             bit=(thr>>i)&1
             self.bits[61+i]=bit
-            
+
+    def set_toa_dac_threshold(self,thr):
+        thr=thr&0x3ff
+        for i in range(0,10):
+            bit=(thr>>i)&1
+            self.bits[51+i]=bit
+
     def Print(self):
         print(self.bits)


### PR DESCRIPTION
In analogy to the TOT DAC threshold, adding the TOA DAC threshold into the code and default config (default threshold being 270 DAC units).

Bit address based on the SK2cms slow control file:
![image](https://user-images.githubusercontent.com/4972492/44908220-fd95ad80-ad1a-11e8-82bc-0b7aea8235fc.png)

To be tested before merging.
